### PR TITLE
fix nonexistent branch error when cloning submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ in production.
 
 ## Use
 
-1. Clone this repository and submodules
+1. Clone this repository and submodules `git clone --recursive https://github.com/WMInfoTech/vagrant-mdid.git`
 2. `vagrant up` (If you encounter any issues here, run `vagrant provision`
     to clean them up)
 3. `vagrant ssh`


### PR DESCRIPTION
Hey, I just saw your vagrant project -- awesome!  

It looks like a commit/branch got pruned though, so this just fixes that and points to your rooibos fork's latest WMInfoTech/vagrant-mdid@32be324bff

Anyone from WM going to VRA2015?  If so, I'll see you there!  
